### PR TITLE
MP-56:  signed route fixes

### DIFF
--- a/signer.py
+++ b/signer.py
@@ -89,7 +89,11 @@ class Signer:
     """Calculate a request signature based on given context"""
     # pylint: disable=too-many-branches,unused-argument
     hasher = hashlib.md5()
-    url = url.replace('+', '%2B')
+
+    pre_parsed_url = urllib.parse.urlparse(url)
+    url = f'{pre_parsed_url.scheme}://{pre_parsed_url.netloc}{pre_parsed_url.path}'
+    if pre_parsed_url.query != '':
+      url += f"?{pre_parsed_url.query.replace('+', '%2B')}"
 
     if isinstance(body, (bytes, bytearray)):
       hasher.update(body)


### PR DESCRIPTION
This update is required because nginx converts `%2B` back into a `+`  in the URI portion of a URL but not the query parameters. For example this url `/ic/email-auth/groups/saml/testing%2B123@lumavate.com?email=johndoe%2B@example.com` would turn into `/ic/email-auth/groups/saml/testing+123@lumavate.com?email=johndoe%2B@example.com`. This messes up the encoding on godspeeds side because it creates the signature thinking we sent the second url when it was actually the first. Our solution is to only encode the query parameter portion of the url. 