### PR TITLE
PLAT3-1765: Updating url for signing request

### DIFF
--- a/signer.py
+++ b/signer.py
@@ -7,7 +7,6 @@ import json
 import time
 import hmac
 import base64
-import pyro
 
 try:
   from flask import request
@@ -80,7 +79,8 @@ class Signer:
 
   def get_request_signing_errors(self):
     """Check if the current request (in context) has been properly signed"""
-    derived_url = request.url.replace(request.host, pyro.Request.ExperienceCloud.get_host_from_headers(request))
+    forward_host = next((value for (key, value) in request.headers if key.lower() == 'x-forwarded-host'), None)
+    derived_url = request.url.replace(request.host, forward_host) if forward_host else request.url
     return self.get_signing_errors(
         request.method.lower(),
         derived_url,

--- a/signer.py
+++ b/signer.py
@@ -7,6 +7,7 @@ import json
 import time
 import hmac
 import base64
+import pyro
 
 try:
   from flask import request
@@ -79,9 +80,10 @@ class Signer:
 
   def get_request_signing_errors(self):
     """Check if the current request (in context) has been properly signed"""
+    derived_url = request.url.replace(request.host, pyro.Request.ExperienceCloud.get_host_from_headers(request))
     return self.get_signing_errors(
         request.method.lower(),
-        request.url,
+        derived_url,
         request.get_data(),
         request.headers)
 


### PR DESCRIPTION
With removal of the custom domain names of the api gateways, the url in the signer needs to match the signing value using a custom header, which is equal to the custom domain. 